### PR TITLE
Update to go version 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,5 +9,4 @@ jobs:
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
       build_dep: |
-        gardenlinux/package-golang 1.25.7-2gl0
-        gardenlinux/package-golang-defaults 1.25gl0
+        gardenlinux/package-golang 1.26.1-1gl0


### PR DESCRIPTION
**What this PR does / why we need it**:
Update to build with go version `1.26`.
Since Debian's default go version switched from `1.24` to `1.26`, our custom `golang-defaults` package is no longer needed.

**Which issue(s) this PR fixes**:
Part of: https://github.com/gardenlinux/gardenlinux/issues/4504