### PR TITLE
Update version to 1.4.2

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
-version_orig="1.4.0"
-version="1.4.0-1"
+version_orig="1.4.2"
+version="1.4.2-1"
 message="New upstream version ${version_orig}"
 
-SALSA_REPO_COMMIT="937efd87a20dea89c728e468fccacdcf3dcfb5eb" # latest on 05.02.2026
+SALSA_REPO_COMMIT="f0805cf43016c099e5651801c83633b3ac5a777c" # latest on 2026-03-29
 
 git_src_commit v${version_orig} https://github.com/opencontainers/runc.git
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update runc to 1.4.2

**Which issue(s) this PR fixes**:
Fixes [#gardenlinux/issues/4604](https://github.com/gardenlinux/gardenlinux/issues/4604)

**Special notes for your reviewer**:
https://github.com/gardenlinux/package-runc/actions/runs/24338397388 build seems to have worked

