### PR TITLE
chore: rebuild with golang to 1.26.2-1gl0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,4 +9,4 @@ jobs:
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
       build_dep: |
-        gardenlinux/package-golang 1.26.1-1gl0
+        gardenlinux/package-golang 1.26.2-1gl0

--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,6 @@
 version_orig="1.4.0"
 version="1.4.0-1"
+version_suffix=gl2
 message="New upstream version ${version_orig}"
 
 SALSA_REPO_COMMIT="937efd87a20dea89c728e468fccacdcf3dcfb5eb" # latest on 05.02.2026

--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
-version_orig="1.4.0"
-version="1.4.0-1"
+version_orig="1.4.1"
+version="1.4.1-1"
 version_suffix=gl2
 message="New upstream version ${version_orig}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
because update golang

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4604