### PR TITLE
chore: update golang to 1.26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,4 +9,4 @@ jobs:
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
       build_dep: |
-        gardenlinux/package-golang 1.26.1-1gl0
+        gardenlinux/package-golang 1.26.2-1gl0


### PR DESCRIPTION
**What this PR does / why we need it**:
Update build dependency to golang 1.26.2

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4604
