### PR TITLE
Update/update rel 2150 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,4 +9,4 @@ jobs:
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
       build_dep: |
-        gardenlinux/package-golang 1.26.1-1gl0
+        gardenlinux/package-golang 1.26.2-1gl0

--- a/prepare_source
+++ b/prepare_source
@@ -1,9 +1,10 @@
-version_orig="1.4.1"
-version="1.4.1-1"
-version_suffix=gl2
+version_orig="1.4.2"
+version="1.4.2-1"
+version_suffix=gl1
+
 message="New upstream version ${version_orig}"
 
-SALSA_REPO_COMMIT="937efd87a20dea89c728e468fccacdcf3dcfb5eb" # latest on 05.02.2026
+SALSA_REPO_COMMIT="f0805cf43016c099e5651801c83633b3ac5a777c" # latest on 2026-03-29
 
 git_src_commit v${version_orig} https://github.com/opencontainers/runc.git
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick the two changes from main to rel-2150, also: as a package was already built when updating the runc version, a new version has to be build with the updated go dependency, hence the gl postfix was increased to gl1

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4604