### PR TITLE
fix: Build on main without a fixed go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,5 +8,3 @@ jobs:
     uses: gardenlinux/package-build/.github/workflows/build.yml@main
     with:
       release: ${{ github.ref == 'refs/heads/main' }}
-      build_dep: |
-        gardenlinux/package-golang 1.26.2-1gl0


### PR DESCRIPTION
Pinning the build-dep on main is not required and potentially uses an old version to build for new releases, if not also updated.