### PR TITLE
Update version to 1.4.3 in `main` (rel-2150 is already 1.4.3)

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,5 @@
-version_orig="1.4.2"
-version="1.4.2-1"
+version_orig="1.4.3"
+version="1.4.3-1"
 message="New upstream version ${version_orig}"
 
 SALSA_REPO_COMMIT="f0805cf43016c099e5651801c83633b3ac5a777c" # latest on 2026-03-29


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Version to 1.4.3 to sync with `rel-2150` branch (Missed)

**Which issue(s) this PR fixes**:
Fixes [update runc for 2150.7.0](https://github.com/gardenlinux/gardenlinux/issues/5011)
